### PR TITLE
Notes Applet Backend (FastAPI and MongoDB)

### DIFF
--- a/backend/src/app.py
+++ b/backend/src/app.py
@@ -7,6 +7,9 @@ from src.paths import (
     signup,
     student_routes
 )
+from src.paths.app import (
+    notes
+)
 
 app = FastAPI()
 
@@ -25,3 +28,6 @@ app.include_router(login.router)
 app.include_router(signup.router)
 app.include_router(student_routes.router)
 app.include_router(test.router) # remove everything for tests endpoint eventually
+
+# applet routers
+app.include_router(notes.router)

--- a/backend/src/dbfuncs/notes.py
+++ b/backend/src/dbfuncs/notes.py
@@ -55,6 +55,8 @@ async def get_note(email: str, note_id: str):
 
 async def update_note(email: str, note_id: str, title: str=None, adjacent: list[str]=None, text: str=None):
     try: 
+        if await collection.find_one({"email": email, "_id": ObjectId(note_id)}) is None:
+            return None
         adjancent_ids = None if adjacent is None else list(map(lambda x: ObjectId(x), adjacent))
         fields = [("title", title), ("adjacent_note_ids", adjancent_ids), ("text", text)]
         counts = await asyncio.gather(*[update_field(email, note_id, x[0], x[1]) for x in fields])

--- a/backend/src/dbfuncs/notes.py
+++ b/backend/src/dbfuncs/notes.py
@@ -1,0 +1,38 @@
+import os
+from dotenv import load_dotenv
+from bson.objectid import ObjectId
+from pymongo.errors import DuplicateKeyError
+import motor.motor_asyncio
+
+load_dotenv()
+connection_string = os.getenv("ConnectionString")
+client = motor.motor_asyncio.AsyncIOMotorClient(connection_string)
+database = client.SAIO
+collection = database.notes_test
+user_collection = database.users
+
+async def get_note(email: str, _id: str):
+    object_id = ObjectId()
+
+    if _id == None:
+        print("finding root")
+        # if _id is not given, find the user's root note
+        # and create a root note if needed
+        result = await user_collection.find_one({"email": email})
+        object_id = result.get("root_note_id")
+
+        if object_id == None:
+            print("creating root since none was found")
+            # if there is no root note, create one
+            object_id = (await collection.insert_one({
+                "email": email,
+                "title": "Your Root Note",
+                "adjacent_note_ids": [],
+                "text": "Welcome to the Notes Applet! You are looking at your root note. A note can contain text and links to other notes. Try it out by clicking around!"
+            })).inserted_id
+            # link new root id to account
+            await user_collection.update_one({"email": email}, { "$set": {"root_note_id": object_id}})
+    else:
+        object_id = ObjectId(_id)  
+    
+    return await collection.find_one({"_id": object_id, "email": email})

--- a/backend/src/dbfuncs/notes.py
+++ b/backend/src/dbfuncs/notes.py
@@ -10,7 +10,7 @@ load_dotenv()
 connection_string = os.getenv("ConnectionString")
 client = motor.motor_asyncio.AsyncIOMotorClient(connection_string)
 database = client.SAIO
-collection = database.notes_test
+collection = database.notes
 user_collection = database.users
 
 ROOT_NOTE_DEFAULT_TEXT = "Welcome to the Notes Applet! You are looking at your root note. A note can contain text and links to other notes. Try it out by clicking around!"

--- a/backend/src/models/common.py
+++ b/backend/src/models/common.py
@@ -1,0 +1,4 @@
+from pydantic import BaseModel
+
+class MessageResponse(BaseModel):
+    message: str

--- a/backend/src/models/common.py
+++ b/backend/src/models/common.py
@@ -1,4 +1,16 @@
 from pydantic import BaseModel
 
 class MessageResponse(BaseModel):
-    message: str
+    detail: str = 'Message'
+
+class OkResponse(BaseModel):
+    detail: str = 'OK'
+
+class BadResponse(BaseModel):
+    detail: str = 'Bad request'
+
+class NotFoundResponse(BaseModel):
+    detail: str = 'Not found'
+
+class UnprocessableResponse(BaseModel):
+    detail: str = 'Unprocessable entity'

--- a/backend/src/models/notes.py
+++ b/backend/src/models/notes.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+class GetNoteRequest(BaseModel):
+    email: str
+    _id: str
+
+class GetNoteResponse(BaseModel):
+    title: str
+    adjacent: list[str]
+    text: str

--- a/backend/src/models/notes.py
+++ b/backend/src/models/notes.py
@@ -1,8 +1,24 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 class GetNoteRequest(BaseModel):
     email: str
     _id: str
+
+class UpdateNoteRequest(BaseModel):
+    title: str | None = Field(
+        default=None, title="The updated title.")
+    adjacent: list[str] | None = Field(
+        default=None, title="The updated adjancent note IDs.", max_length=300)
+    text: str | None = Field(
+        default=None, title="The updated text.")
+
+class Item(BaseModel):
+    name: str
+    description: str | None = Field(
+        default=None, title="The description of the item", max_length=300
+    )
+    price: float = Field(gt=0, description="The price must be greater than zero")
+    tax: float | None = None
 
 class CreateNoteResponse(BaseModel):
     note_id: str

--- a/backend/src/models/notes.py
+++ b/backend/src/models/notes.py
@@ -4,6 +4,9 @@ class GetNoteRequest(BaseModel):
     email: str
     _id: str
 
+class CreateNoteResponse(BaseModel):
+    note_id: str
+
 class GetNoteResponse(BaseModel):
     title: str
     adjacent: list[str]

--- a/backend/src/paths/app/notes.py
+++ b/backend/src/paths/app/notes.py
@@ -1,7 +1,7 @@
-from typing import Annotated, Union
+from typing import Annotated, Optional
 from fastapi import APIRouter, Header, HTTPException, Response
 from fastapi.responses import JSONResponse
-from ...models.common import ( MessageResponse )
+from ...models.common import *
 from ...models.notes import *
 from ...dbfuncs import notes as funcs
 
@@ -10,48 +10,50 @@ router = APIRouter(
     tags=['Notes']
 )
 
-@router.post("")
+@router.post('',
+    responses = {200: {'model': CreateNoteResponse}, 400: {'model': NotFoundResponse}},
+    response_model = CreateNoteResponse)
 async def create_note(
-        x_email: Annotated[str | None, Header()] = None,
-    ) -> CreateNoteResponse:    
+        x_email: Annotated[str | None, Header()] = None):    
     
     inserted_id: str = await funcs.create_note(x_email);
 
     if inserted_id == None:
-        raise
+        raise HTTPException(status_code=400, detail='Something went wrong')
 
-    return CreateNoteResponse(
-        note_id = str(inserted_id)
-    )
+    return CreateNoteResponse(note_id = str(inserted_id))
 
-@router.get("/{note_id:str}",
-    responses = {200: {"model": GetNoteResponse}, 404: {"model": MessageResponse}},
+@router.get('/',
+    responses = {200: {'model': GetNoteResponse}, 404: {'model': NotFoundResponse}},
+    response_model = GetNoteResponse)
+async def get_root_note(
+        x_email: Annotated[str | None, Header()]):
+    return await get_note(x_email, None)
+
+@router.get('/{note_id:str}',
+    responses = {200: {'model': GetNoteResponse}, 404: {'model': NotFoundResponse}},
     response_model = GetNoteResponse)
 async def get_note(
         x_email: Annotated[str | None, Header()],
-        note_id: str):
+        note_id: str = None):
 
     note: dict = await funcs.get_note(x_email, note_id)
 
     if note == None or note.get('_id') == None:
-        return MessageResponse(status_code=404, message="Not found")
+        raise HTTPException(status_code=404, detail='Not found')
     
-    print(note)
     title: str = note.get('title')
     adjacent: list[str] = map(lambda x: str(x), note.get('adjacent_note_ids'))
-    text: str = "" if note.get('text') == None else note.get('text')
+    text: str = '' if note.get('text') == None else note.get('text')
     
-    return JSONResponse(
-        status_code = 200,
-        content = {
-            "title": title,
-            "adjacent": adjacent,
-            "text": text
-        }
+    return GetNoteResponse(
+        title = title,
+        adjacent = adjacent,
+        text = text
     )
 
-@router.patch("/{note_id:str}",
-    responses = {200: {"model": MessageResponse}, 400: {"model": MessageResponse}, 404: {"model": MessageResponse}, 422: {"model": MessageResponse}},
+@router.patch('/{note_id:str}',
+    responses = {200: {'model': OkResponse}, 400: {'model': BadResponse}, 404: {'model': NotFoundResponse}},
     response_model = MessageResponse)
 async def update_note(
         request: UpdateNoteRequest,
@@ -59,19 +61,20 @@ async def update_note(
         note_id: str):
     result = await funcs.update_note(x_email, note_id, request.title, request.adjacent, request.text)
 
-    print(note_id)
-    print(request)
+    print(result)
     
-    if result == -1:
-        return JSONResponse(status_code=400, content={"message":"Invalid Note Id"})
+    if result == None:
+        raise HTTPException(status_code=404, detail='Note not found')
+    elif result == -1:
+        raise HTTPException(status_code=400, detail='Invalid Note Id')
     elif result == 0:
-        return JSONResponse(status_code=400, content={"message":"No data changed"})
+        return JSONResponse(status_code=400, detail='No data changed')
     
-    return JSONResponse(status_code=200, content={"message":"OK"})
+    return MessageResponse(message='OK')
 
-@router.delete("/{note_id:str}",
-    responses = {200: {"model": MessageResponse}, 400: {"model": MessageResponse}, 404: {"model": MessageResponse}, 422: {"model": MessageResponse}},
-    response_model = MessageResponse)
+@router.delete('/{note_id:str}',
+    responses = {400: {'model': BadResponse}, 404: {'model': NotFoundResponse}},
+    response_model = OkResponse)
 async def delete_note(
         x_email: Annotated[str | None, Header()],
         note_id: str):
@@ -79,10 +82,10 @@ async def delete_note(
     result = await funcs.delete_note(x_email, note_id)
 
     if result is None:
-        return JSONResponse(status_code=422, content={"message":"Cannot delete root note"})
+        raise HTTPException(status_code=400, detail='Cannot delete root note')
     elif result == 0:
-        return JSONResponse(status_code=404, content={"message":"Note not found"})
+        raise HTTPException(status_code=404, detail='Note not found')
     elif result == -1:
-        return JSONResponse(status_code=400, content={"message":"Invalid Note Id"})
+        raise HTTPException(status_code=400, detail='Invalid Note Id')
     
-    return MessageResponse(status_code=200, message="OK")
+    return OkResponse

--- a/backend/src/paths/app/notes.py
+++ b/backend/src/paths/app/notes.py
@@ -1,4 +1,7 @@
-from fastapi import APIRouter
+from typing import Annotated
+from fastapi import APIRouter, Header, HTTPException
+from ...models.notes import ( GetNoteRequest, GetNoteResponse )
+from ...dbfuncs.notes import ( get_note )
 
 router = APIRouter(
     prefix='/app/notes',
@@ -10,8 +13,25 @@ async def create_note():
     pass
 
 @router.get("")
-async def read_note():
-    pass
+async def read_note(
+        x_email: Annotated[str | None, Header()] = None,
+        x_note_id: Annotated[str | None, Header()] = None
+    ) -> GetNoteResponse:
+
+    print("X-EMAIL:" + x_email)
+    result = await get_note(x_email, x_note_id)
+
+    if result == None or result.get('_id') == None:
+        raise HTTPException(status_code=404, detail="Item not found")
+    
+    print(result)
+    print(result.get('adjacent_note_ids'))
+
+    return GetNoteResponse(
+        title = result.get('title'),
+        adjacent = map(lambda x: str(x), result.get('adjacent_note_ids')),
+        text = result.get('text')
+    )
 
 @router.patch("")
 async def update_note():

--- a/backend/src/paths/app/notes.py
+++ b/backend/src/paths/app/notes.py
@@ -1,6 +1,8 @@
-from typing import Annotated
-from fastapi import APIRouter, Header, HTTPException
-from ...models.notes import ( CreateNoteResponse, GetNoteResponse )
+from typing import Annotated, Union
+from fastapi import APIRouter, Header, HTTPException, Response
+from fastapi.responses import JSONResponse
+from ...models.common import ( MessageResponse )
+from ...models.notes import *
 from ...dbfuncs import notes as funcs
 
 router = APIRouter(
@@ -22,32 +24,65 @@ async def create_note(
         note_id = str(inserted_id)
     )
 
-@router.get("")
+@router.get("/{note_id:str}",
+    responses = {200: {"model": GetNoteResponse}, 404: {"model": MessageResponse}},
+    response_model = GetNoteResponse)
 async def get_note(
-        x_email: Annotated[str | None, Header()] = None,
-        x_note_id: Annotated[str | None, Header()] = None
-    ) -> GetNoteResponse:
+        x_email: Annotated[str | None, Header()],
+        note_id: str):
 
-    note: dict = await funcs.get_note(x_email, x_note_id)
+    note: dict = await funcs.get_note(x_email, note_id)
 
     if note == None or note.get('_id') == None:
-        raise HTTPException(status_code=404, detail="Note not found")
+        return MessageResponse(status_code=404, message="Not found")
     
     print(note)
     title: str = note.get('title')
     adjacent: list[str] = map(lambda x: str(x), note.get('adjacent_note_ids'))
     text: str = "" if note.get('text') == None else note.get('text')
     
-    return GetNoteResponse(
-        title = title,
-        adjacent = adjacent,
-        text = text
+    return JSONResponse(
+        status_code = 200,
+        content = {
+            "title": title,
+            "adjacent": adjacent,
+            "text": text
+        }
     )
 
-@router.patch("")
-async def update_note():
-    pass
+@router.patch("/{note_id:str}",
+    responses = {200: {"model": MessageResponse}, 400: {"model": MessageResponse}, 404: {"model": MessageResponse}, 422: {"model": MessageResponse}},
+    response_model = MessageResponse)
+async def update_note(
+        request: UpdateNoteRequest,
+        x_email: Annotated[str | None, Header()],
+        note_id: str):
+    result = await funcs.update_note(x_email, note_id, request.title, request.adjacent, request.text)
 
-@router.delete("")
-async def delete_note():
-    pass
+    print(note_id)
+    print(request)
+    
+    if result == -1:
+        return JSONResponse(status_code=400, content={"message":"Invalid Note Id"})
+    elif result == 0:
+        return JSONResponse(status_code=400, content={"message":"No data changed"})
+    
+    return JSONResponse(status_code=200, content={"message":"OK"})
+
+@router.delete("/{note_id:str}",
+    responses = {200: {"model": MessageResponse}, 400: {"model": MessageResponse}, 404: {"model": MessageResponse}, 422: {"model": MessageResponse}},
+    response_model = MessageResponse)
+async def delete_note(
+        x_email: Annotated[str | None, Header()],
+        note_id: str):
+    
+    result = await funcs.delete_note(x_email, note_id)
+
+    if result is None:
+        return JSONResponse(status_code=422, content={"message":"Cannot delete root note"})
+    elif result == 0:
+        return JSONResponse(status_code=404, content={"message":"Note not found"})
+    elif result == -1:
+        return JSONResponse(status_code=400, content={"message":"Invalid Note Id"})
+    
+    return MessageResponse(status_code=200, message="OK")

--- a/backend/src/paths/app/notes.py
+++ b/backend/src/paths/app/notes.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter
+
+router = APIRouter(
+    prefix='/app/notes',
+    tags=['Notes']
+)
+
+@router.post("")
+async def create_note():
+    pass
+
+@router.get("")
+async def read_note():
+    pass
+
+@router.patch("")
+async def update_note():
+    pass
+
+@router.delete("")
+async def delete_note():
+    pass


### PR DESCRIPTION
Changes for this branch involve the backend for the notes app. The notes has a graph-like design where each note contains links to other notes as well as the usual content. These structure is meant to be flexible and allow users to organize their notes how they want it. We'll see how they like it in beta!
- The MongoDB collection I created is called "notes" and there is no validation for it at the moment. Can add it if we need it.
  - A document in notes has the "email", "title", "text", and "adjacent_note_ids" fields (alongside the _id)
- The FastAPI frontend has endpoints for each CRUD action. GET has two as a technicality because path parameters cannot be optional.
  - The (GET) endpoint returns the user's root note if no ID is specified. User cannot delete their root note at the moment.
  - Included default text for the root note and new notes, too.
- Tried my best for the OpenAPI spec to be useful, but for some reason FastAPI's docs for error responses isn't elegant, I had to duplicate code pretty much.
I tested the endpoints, and everything is working as expected as far as I can tell. You should be able to use any existing account for testing. I used s@s.com for testing.